### PR TITLE
Add picture (base64) in credential details

### DIFF
--- a/core/App/components/record/RecordField.tsx
+++ b/core/App/components/record/RecordField.tsx
@@ -1,7 +1,7 @@
 import startCase from 'lodash.startcase'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
-import { StyleSheet, Text, TouchableOpacity, View } from 'react-native'
+import { Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native'
 
 import { useTheme } from '../../contexts/theme'
 import { Attribute, Field } from '../../types/record'
@@ -26,6 +26,8 @@ const RecordField: React.FC<RecordFieldProps> = ({
 }) => {
   const { t } = useTranslation()
   const { ListItems } = useTheme()
+  const regexImageBase64 = new RegExp('^data:image/(jpeg|png);base64,')
+
   const styles = StyleSheet.create({
     container: {
       ...ListItems.recordContainer,
@@ -36,6 +38,12 @@ const RecordField: React.FC<RecordFieldProps> = ({
       ...ListItems.recordBorder,
       borderBottomWidth: 2,
       paddingTop: 12,
+    },
+    image: {
+      height: 150,
+      aspectRatio: 1,
+      resizeMode: 'contain',
+      borderRadius: 10,
     },
     link: {
       ...ListItems.recordLink,
@@ -55,6 +63,14 @@ const RecordField: React.FC<RecordFieldProps> = ({
     },
   })
 
+  const displayAttribute = (attribute: Attribute) => {
+    if (typeof attribute.value === 'string' && regexImageBase64.test(attribute.value)) {
+      return <Image testID={testIdWithKey('credentialImage')} style={styles.image} source={{ uri: attribute.value }} />
+    } else {
+      return attribute.value
+    }
+  }
+
   return (
     <View style={styles.container}>
       {fieldLabel ? (
@@ -71,7 +87,7 @@ const RecordField: React.FC<RecordFieldProps> = ({
           <>
             <View style={styles.valueText}>
               <Text style={styles.text} testID={testIdWithKey('AttributeValue')}>
-                {shown ? (field as Attribute).value : Array(10).fill('\u2022').join('')}
+                {shown ? displayAttribute(field as Attribute) : Array(10).fill('\u2022').join('')}
               </Text>
             </View>
             {hideFieldValue ? (

--- a/core/__tests__/screens/CredentialDetails.test.tsx
+++ b/core/__tests__/screens/CredentialDetails.test.tsx
@@ -6,6 +6,7 @@ import React from 'react'
 
 import { dateFormatOptions } from '../../App/constants'
 import CredentialDetails from '../../App/screens/CredentialDetails'
+import { testIdWithKey } from '../../App/utils/testable'
 
 interface CredentialContextInterface {
   loading: boolean
@@ -54,6 +55,11 @@ describe('displays a credential details screen', () => {
       {
         name: 'postalCode',
         value: 'V1V1V1',
+        toJSON: jest.fn(),
+      },
+      {
+        name: 'picture',
+        value: 'data:image/png;base64,',
         toJSON: jest.fn(),
       },
     ],
@@ -133,7 +139,7 @@ describe('displays a credential details screen', () => {
 
     const hiddenValues = await findAllByText(Array(10).fill('\u2022').join(''))
 
-    expect(hiddenValues.length).toBe(3)
+    expect(hiddenValues.length).toBe(4)
   })
 
   test('pressing the `Show` button un-hides an attribute value', async () => {
@@ -148,8 +154,8 @@ describe('displays a credential details screen', () => {
     let hiddenValues = await findAllByText(Array(10).fill('\u2022').join(''))
     let familyName = await queryByText('Last', { exact: false })
 
-    expect(showButtons.length).toBe(3)
-    expect(hiddenValues.length).toBe(3)
+    expect(showButtons.length).toBe(4)
+    expect(hiddenValues.length).toBe(4)
     expect(familyName).toBe(null)
 
     fireEvent(showButtons[0], 'press')
@@ -158,8 +164,8 @@ describe('displays a credential details screen', () => {
     hiddenValues = await findAllByText(Array(10).fill('\u2022').join(''))
     familyName = await queryByText('Last', { exact: false })
 
-    expect(showButtons.length).toBe(2)
-    expect(hiddenValues.length).toBe(2)
+    expect(showButtons.length).toBe(3)
+    expect(hiddenValues.length).toBe(3)
     expect(familyName).not.toBe(null)
   })
 
@@ -191,7 +197,32 @@ describe('displays a credential details screen', () => {
     showButtons = await findAllByText('Record.Show')
     hiddenValues = await findAllByText(Array(10).fill('\u2022').join(''))
 
-    expect(showButtons.length).toBe(3)
-    expect(hiddenValues.length).toBe(3)
+    expect(showButtons.length).toBe(4)
+    expect(hiddenValues.length).toBe(4)
   }, 10000)
+
+  test('pressing the `Show` button un-hides an attribute that is a base64 image', async () => {
+    const { queryByText, findAllByText, queryByTestId } = render(
+      <CredentialDetails
+        navigation={useNavigation()}
+        route={{ params: { credentialId: testCredentialRecords.credentials[0].id } } as any}
+      ></CredentialDetails>
+    )
+
+    const showButtons = await findAllByText('Record.Show')
+
+    let pictureBase64AsString = await queryByText('data:image/png;base64,', { exact: false })
+    let picture = await queryByTestId(testIdWithKey('credentialImage'))
+
+    expect(picture).toBeNull()
+    expect(pictureBase64AsString).toBeNull()
+
+    fireEvent(showButtons[3], 'press')
+
+    pictureBase64AsString = await queryByText('data:image/png;base64,', { exact: false })
+    picture = await queryByTestId(testIdWithKey('credentialImage'))
+
+    expect(picture).not.toBeNull()
+    expect(pictureBase64AsString).toBeNull()
+  })
 })


### PR DESCRIPTION
# Summary of Changes

This PR adds the display of pictures in base64 for the CredentialDetails screen.

# Related Issues

n/a

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [x] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [x] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [x] Updated documentation as needed for changed code and new or modified features;
- [x] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
